### PR TITLE
add grammars for .in templates (and some sublanguages)

### DIFF
--- a/grammars/cmake template batch.cson
+++ b/grammars/cmake template batch.cson
@@ -1,0 +1,15 @@
+'fileTypes': [
+  'bat.in'
+  'cmd.in'
+]
+'name': 'CMake Template Batch'
+'patterns': [
+  {
+    'include': 'source.cmake.template'
+  }
+  {
+    'comment': 'Batch source'
+    'include': 'source.bat'
+  }
+]
+'scopeName': 'source.cmake.template.bat'

--- a/grammars/cmake template c.cson
+++ b/grammars/cmake template c.cson
@@ -1,0 +1,15 @@
+'fileTypes': [
+  'c.in'
+  'h.in'
+]
+'name': 'CMake Template C'
+'patterns': [
+  {
+    'include': 'source.cmake.template'
+  }
+  {
+    'comment': 'C source'
+    'include': 'source.c'
+  }
+]
+'scopeName': 'source.cmake.template.c'

--- a/grammars/cmake template cmake.cson
+++ b/grammars/cmake template cmake.cson
@@ -1,0 +1,14 @@
+'fileTypes': [
+  'cmake.in'
+]
+'name': 'CMake Template CMake'
+'patterns': [
+  {
+    'include': 'source.cmake.template'
+  }
+  {
+    'comment': 'CMake source'
+    'include': 'source.cmake'
+  }
+]
+'scopeName': 'source.cmake.template.cmake'

--- a/grammars/cmake template cpp.cson
+++ b/grammars/cmake template cpp.cson
@@ -1,0 +1,30 @@
+'fileTypes': [
+  'cc.in'
+  'cpp.in'
+  'cp.in'
+  'cxx.in'
+  'c++.in'
+  'cu.in'
+  'cuh.in'
+  'h.in'
+  'hh.in'
+  'hpp.in'
+  'hxx.in'
+  'h++.in'
+  'inl.in'
+  'ino.in'
+  'ipp.in'
+  'tcc.in'
+  'tpp.in'
+]
+'name': 'CMake Template C++'
+'patterns': [
+  {
+    'include': 'source.cmake.template'
+  }
+  {
+    'comment': 'C++ source'
+    'include': 'source.cpp'
+  }
+]
+'scopeName': 'source.cmake.template.cpp'

--- a/grammars/cmake template python.cson
+++ b/grammars/cmake template python.cson
@@ -1,0 +1,27 @@
+'fileTypes': [
+  'cpy.in'
+  'gyp.in'
+  'gypi.in'
+  'kv.in'
+  'py.in'
+  'pyw.in'
+  'rpy.in'
+  'SConscript.in'
+  'SConstruct.in'
+  'Sconstruct.in'
+  'sconstruct.in'
+  'Snakefile.in'
+  'tac.in'
+  'wsgi.in'
+]
+'name': 'CMake Template Python'
+'patterns': [
+  {
+    'include': 'source.cmake.template'
+  }
+  {
+    'comment': 'Python source'
+    'include': 'source.python'
+  }
+]
+'scopeName': 'source.cmake.template.cmake'

--- a/grammars/cmake template shell-unix-bash.cson
+++ b/grammars/cmake template shell-unix-bash.cson
@@ -1,0 +1,35 @@
+'fileTypes': [
+  'sh.in'
+  'bash.in'
+  'ksh.in'
+  'zsh.in'
+  'zsh-theme.in'
+  'zshenv.in'
+  'zlogin.in'
+  'zlogout.in'
+  'zprofile.in'
+  'zshrc.in'
+  'bashrc.in'
+  'bash_profile.in'
+  'bash_login.in'
+  'profile.in'
+  'bash_logout.in'
+  '.textmate_init.in'
+  'npmrc.in'
+  'PKGBUILD.in'
+  'install.in'
+  'cygport.in'
+  'bats.in'
+  'ebuild.in'
+]
+'name': 'CMake Template Shell Script'
+'patterns': [
+  {
+    'include': 'source.cmake.template'
+  }
+  {
+    'comment': 'Shell source'
+    'include': 'source.shell'
+  }
+]
+'scopeName': 'source.cmake.template.shell'

--- a/grammars/cmake template.cson
+++ b/grammars/cmake template.cson
@@ -1,0 +1,24 @@
+'fileTypes': [
+  'in'
+]
+'name': 'CMake Template'
+'patterns': [
+  {
+    'comment': 'CMake variable'
+    'begin': '@'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.variable.begin.cmake'
+    'end': '@'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.variable.end.cmake'
+    'name': 'variable.parameter.cmake'
+    'patterns': [
+      {
+        'match': '\\w+'
+      }
+    ]
+  }
+]
+'scopeName': 'source.cmake.template'


### PR DESCRIPTION
This PR implements #9 and adds a grammar for `.in` templates as well as some variations for the following sub languages: Batch, C, CMake, C++, Python, Shell Script. More sub languages can easily be added when needed.