### PR TITLE
Fix coloring of opening parenthesis.

### DIFF
--- a/grammars/cmake listfile.cson
+++ b/grammars/cmake listfile.cson
@@ -33,7 +33,7 @@
         'name': 'keyword.control.cmake'
       '2':
         'name': 'support.function.cmake'
-      '3':
+      '4':
         'name': 'punctuation.definition.parameters.begin.command.cmake'
     'comment': 'The command list is simply generated with:\n\t\t\t\tcmake --help-command-list | ruby /Library/Application\\ Support/TextMate/Bundles/Objective-C.tmbundle/Support/list_to_regexp.rb | pbcopy'
     'end': '(\\))'


### PR DESCRIPTION
Currently the `beginCaptures` numbering is off by one.

Before:
![image](https://user-images.githubusercontent.com/15164633/42405461-0dd97c86-8164-11e8-82db-d2322085f53e.png)

After:
![image](https://user-images.githubusercontent.com/15164633/42405464-18fcf7aa-8164-11e8-97ab-d896ead89b6e.png)


